### PR TITLE
Add Windows Compatibility + NumPy 1.20 Support 

### DIFF
--- a/bytetrack_realtime/byte_tracker.py
+++ b/bytetrack_realtime/byte_tracker.py
@@ -12,7 +12,7 @@ class STrack(BaseTrack):
     def __init__(self, ltwh, score, det_class):
 
         # wait activate
-        self._ltwh = np.asarray(ltwh, dtype=np.float)
+        self._ltwh = np.asarray(ltwh, dtype=np.float64)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/bytetrack_realtime/bytetrack/matching.py
+++ b/bytetrack_realtime/bytetrack/matching.py
@@ -57,13 +57,13 @@ def ious(altrbs, bltrbs):
 
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(altrbs), len(bltrbs)), dtype=np.float)
+    ious = np.zeros((len(altrbs), len(bltrbs)), dtype=np.float64)
     if ious.size == 0:
         return ious
 
     ious = bbox_ious(
-        np.ascontiguousarray(altrbs, dtype=np.float),
-        np.ascontiguousarray(bltrbs, dtype=np.float)
+        np.ascontiguousarray(altrbs, dtype=np.float64),
+        np.ascontiguousarray(bltrbs, dtype=np.float64)
     )
 
     return ious
@@ -117,13 +117,13 @@ def embedding_distance(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float64)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float64)
     #for i, track in enumerate(tracks):
         #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float64)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
     return cost_matrix
 

--- a/bytetrack_realtime/utils/cython_bbox.pyx
+++ b/bytetrack_realtime/utils/cython_bbox.pyx
@@ -9,8 +9,10 @@ cimport cython
 import numpy as np
 cimport numpy as np
 
-DTYPE = np.float
-ctypedef np.float_t DTYPE_t
+DTYPE = np.float64
+ctypedef np.float64_t DTYPE_t
+
+__version__ = "0.1.5"
 
 def bbox_overlaps(
         np.ndarray[DTYPE_t, ndim=2] boxes,
@@ -46,7 +48,7 @@ def bbox_overlaps(
                     max(boxes[n, 1], query_boxes[k, 1]) + 1
                 )
                 if ih > 0:
-                    ua = float(
+                    ua = DTYPE(
                         (boxes[n, 2] - boxes[n, 0] + 1) *
                         (boxes[n, 3] - boxes[n, 1] + 1) +
                         box_area - iw * ih

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ ext_modules = [
     Extension(
         "cython_bbox",
         ["bytetrack_realtime/utils/cython_bbox.pyx"],
-        extra_compile_args=["-Wno-cpp", "-Wno-unused-function"],
+        extra_compile_args={'gcc': ['/Qstd=c99']},
         include_dirs=[np.get_include()],
     )
 ]
@@ -19,6 +19,6 @@ setup(
     ext_modules=ext_modules,
     install_requires=[
         'cython',
-        "lap"
+        "lapx"
     ]
 )


### PR DESCRIPTION
Fixes `'Wno-cpp'` not being recognized as valid numeric argument (using [this solution](https://github.com/cocodataset/cocoapi/issues/51#issuecomment-379872704)).

Uses `lapx` as package replacement for `lap` to support Windows as well.

Updates `cython_bbox.pyx` to NumPy 1.20 (reference [here](https://github.com/samson-wang/cython_bbox/blob/master/src/cython_bbox.pyx)).